### PR TITLE
Fixing clean up secrets of postman collection experiment

### DIFF
--- a/experiments/run-postman-collection.yaml
+++ b/experiments/run-postman-collection.yaml
@@ -4,7 +4,7 @@ experiments:
       type: postman-collection
       namespace: woodpecker
     parameters:
-      image: "ghcr.io/operantai/woodpecker/woodpecker-postman-collection:latest"
+      image: "ghcr.io/operantai/woodpecker/woodpecker-postman-collection:main"
       imagePullSecret: "my-private-registry" # Optional, if your image is in a private registry. Needs to be created in the namespace beforehand.
       collectionPath: "/postman/postman-collection.yaml" # Path inside the container, default mounted at /postman and the file name is postman-collection.yaml
       schedule: "*/30 * * * *" # Cronjob every 30 minutes

--- a/internal/experiments/experiments_postman_collection.go
+++ b/internal/experiments/experiments_postman_collection.go
@@ -264,7 +264,7 @@ func (p *PostmanCollectionExperimentConfig) Cleanup(ctx context.Context, experim
 
 	for _, env := range config.Parameters.Env {
 		if env.EnvType == "secret" {
-			err = clientset.CoreV1().Secrets(config.Metadata.Namespace).Delete(ctx, env.EnvKey, metav1.DeleteOptions{})
+			err = clientset.CoreV1().Secrets(config.Metadata.Namespace).Delete(ctx, strings.ReplaceAll(env.EnvKey, "_", "-"), metav1.DeleteOptions{})
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
# Changes

* fixing the clean up of secrets removal for the postman collection experiment.
  * Names of the secrets should not have underscores `_`  but only needed for name of secrets and references in K8s resources, the actual names of the env variables inside of the container they DO have the `_` for their names cuz env vars in linux don't allow dashes.
* Updated the expected tag for the postman-collection experiment to `main` 